### PR TITLE
Fix notes panel scrolling

### DIFF
--- a/client/src/components/NotesPanel.jsx
+++ b/client/src/components/NotesPanel.jsx
@@ -219,8 +219,8 @@ export function NotesPanel() {
   }
 
   return (
-    <Card className="h-full shadow-sm">
-      <CardHeader className="flex flex-row items-center justify-between">
+    <Card className="h-full shadow-sm flex flex-col overflow-hidden">
+      <CardHeader className="flex flex-row items-center justify-between flex-shrink-0">
         <CardTitle>Notes</CardTitle>
         <div className="flex gap-2">
           <Button
@@ -241,9 +241,9 @@ export function NotesPanel() {
           </Button>
         </div>
       </CardHeader>
-      <CardContent>
-        <Tabs value={activeNote} onValueChange={setActiveNote}>
-          <div className="relative">
+      <CardContent className="flex-grow overflow-hidden">
+        <Tabs value={activeNote} onValueChange={setActiveNote} className="flex flex-col h-full">
+          <div className="relative flex-shrink-0">
             <TabsList className="w-full max-w-full overflow-x-auto bg-muted [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
               <div className="flex min-w-full px-1">
                 {notes.slice(0, 3).map((note) => (
@@ -282,10 +282,10 @@ export function NotesPanel() {
             <TabsContent
               key={note._id}
               value={note._id}
-              className="mt-4"
+              className="mt-4 flex-grow overflow-hidden flex flex-col"
               hidden={note._id !== activeNote}
             >
-              <div className="border-b border-border pb-2 mb-2">
+              <div className="border-b border-border pb-2 mb-2 flex-shrink-0">
                 <div className="flex gap-1">
                   <Button
                     variant="ghost"
@@ -326,7 +326,7 @@ export function NotesPanel() {
                 </div>
               </div>
 
-              <div className="h-40 overflow-y-auto">
+              <div className="h-40 overflow-y-auto flex-grow scrollbar-hide">
                 <MiniTipTapEditor
                   content={note.content}
                   onUpdate={(content) => handleUpdateNote(note._id, content)}

--- a/client/src/features/Notes/components/NoteEditor.jsx
+++ b/client/src/features/Notes/components/NoteEditor.jsx
@@ -121,7 +121,7 @@ const NoteEditor = ({ note, onUpdateNote, isNewNote, isFullScreen: externalIsFul
   return (
     <div className={editorContainerClasses}>
       {/* Title input */}
-      <div className="border-b border-gray-200 dark:border-gray-700 p-4">
+      <div className="border-b border-gray-200 dark:border-gray-700 p-4 flex-shrink-0">
         <input
           ref={titleInputRef}
           type="text"
@@ -155,12 +155,12 @@ const NoteEditor = ({ note, onUpdateNote, isNewNote, isFullScreen: externalIsFul
       </button>
 
       {/* Editor content */}
-      <div className="flex-grow overflow-auto">
+      <div className="flex-grow overflow-y-auto scrollbar-hide">
         <TipTapEditor content={content} onUpdate={handleTipTapUpdate} isFullScreen={isFullScreen} />
       </div>
 
       {/* Footer with metadata - fixed at bottom when in fullscreen */}
-      <div className={`p-3 border-t border-gray-200 dark:border-gray-700 text-xs text-gray-500 dark:text-gray-400 ${isFullScreen ? 'absolute bottom-0 left-0 right-0 bg-white dark:bg-gray-900' : ''}`}>
+      <div className={`p-3 border-t border-gray-200 dark:border-gray-700 text-xs text-gray-500 dark:text-gray-400 flex-shrink-0 ${isFullScreen ? 'absolute bottom-0 left-0 right-0 bg-white dark:bg-gray-900' : ''}`}>
         <span>Last updated: {new Date(note.updatedAt).toLocaleString()}</span>
       </div>
     </div>

--- a/client/src/features/Notes/components/NotesList.jsx
+++ b/client/src/features/Notes/components/NotesList.jsx
@@ -52,7 +52,7 @@ const NotesList = ({
   return (
     <Card className="h-full w-full border-r border-border flex flex-col overflow-hidden shadow-sm bg-card">
       {/* Header with folder name and create button */}
-      <CardHeader className="border-b border-border flex flex-row items-center justify-between py-3 px-4 space-y-0">
+      <CardHeader className="border-b border-border flex flex-row items-center justify-between py-3 px-4 space-y-0 flex-shrink-0">
         <div className="flex items-center gap-2">
           <FolderIcon className="h-4 w-4 text-primary" />
           <CardTitle className="text-lg font-semibold">
@@ -70,7 +70,7 @@ const NotesList = ({
       </CardHeader>
 
       {/* Notes list */}
-      <CardContent className="overflow-y-auto flex-grow p-0">
+      <CardContent className="overflow-y-auto flex-grow p-0 scrollbar-hide">
         {loading ? (
           <div className="flex justify-center items-center h-32">
             <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-primary shadow-md"></div>

--- a/client/src/features/Notes/components/NotesNavbar.jsx
+++ b/client/src/features/Notes/components/NotesNavbar.jsx
@@ -86,9 +86,9 @@ const NotesNavbar = ({
   };
 
   return (
-    <div className="w-full h-full bg-gray-50 dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 p-4 flex flex-col">
+    <div className="w-full h-full bg-gray-50 dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 p-4 flex flex-col overflow-hidden">
       {/* Search input */}
-      <div className="relative mb-4">
+      <div className="relative mb-4 flex-shrink-0">
         <span className="absolute inset-y-0 left-0 flex items-center pl-3">
           <SearchIcon className="h-4 w-4 text-gray-400" />
         </span>
@@ -102,7 +102,7 @@ const NotesNavbar = ({
       </div>
 
       {/* Folder header with add button */}
-      <div className="flex justify-between items-center mb-2">
+      <div className="flex justify-between items-center mb-2 flex-shrink-0">
         <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
           Folders
         </h2>
@@ -116,7 +116,7 @@ const NotesNavbar = ({
       </div>
 
       {/* Folder list */}
-      <div className="overflow-y-auto flex-grow" onClick={handleClickOutside}>
+      <div className="overflow-y-auto flex-grow scrollbar-hide" onClick={handleClickOutside}>
         <ul className="space-y-1">
           {folders.map((folder) => (
             <li key={folder} className="relative">

--- a/client/src/features/Notes/components/TipTapEditor.jsx
+++ b/client/src/features/Notes/components/TipTapEditor.jsx
@@ -198,13 +198,13 @@ const TipTapEditor = ({ content, onUpdate, isFullScreen }) => {
   }, [content, editor]);
 
   // Apply different styles based on full-screen mode
-  const containerClasses = `flex flex-col h-full overflow-auto transition-all duration-300 ease-in-out ${
+  const containerClasses = `flex flex-col h-full overflow-auto scrollbar-hide transition-all duration-300 ease-in-out ${
     isFullScreen 
       ? "max-w-3xl mx-auto pt-2 pb-16" 
       : "pb-6"
   }`;
 
-  const editorContentClasses = `flex-grow overflow-auto p-4 transition-all duration-300 ease-in-out ${
+  const editorContentClasses = `flex-grow overflow-auto scrollbar-hide p-4 transition-all duration-300 ease-in-out ${
     isFullScreen 
       ? "md:px-8 lg:px-12 animate-in fade-in prose-lg" 
       : ""

--- a/client/src/features/Notes/index.jsx
+++ b/client/src/features/Notes/index.jsx
@@ -290,10 +290,10 @@ const NotesContainer = () => {
   );
 
   return (
-    <div className="h-full overflow-hidden">
-      <PanelGroup direction="horizontal" className="h-full">
+    <div className="h-full flex flex-col overflow-hidden">
+      <PanelGroup direction="horizontal" className="flex-grow overflow-hidden">
         {/* Left sidebar with folders and search - min width 240px (15%) */}
-        <Panel defaultSize={20} minSize={15} className="h-full">
+        <Panel defaultSize={20} minSize={15} className="overflow-hidden flex flex-col">
           <NotesNavbar
             folders={folders}
             currentFolder={currentFolder}
@@ -310,7 +310,7 @@ const NotesContainer = () => {
         <PanelResizeHandle className="w-px bg-border/30 hover:bg-primary/20 transition-colors duration-200" />
 
         {/* Middle section with notes list - min width 240px (15%) */}
-        <Panel defaultSize={25} minSize={15} className="h-full">
+        <Panel defaultSize={25} minSize={15} className="overflow-hidden flex flex-col">
           <NotesList
             notes={filteredNotes}
             selectedNote={selectedNote}
@@ -326,7 +326,7 @@ const NotesContainer = () => {
         <PanelResizeHandle className="w-px bg-border/30 hover:bg-primary/20 transition-colors duration-200" />
 
         {/* Right section with note editor - takes remaining space */}
-        <Panel defaultSize={55} className="h-full">
+        <Panel defaultSize={55} className="overflow-hidden flex flex-col">
           <NoteEditor
             note={selectedNote}
             onUpdateNote={handleUpdateNote}

--- a/client/src/pages/NotesPage.jsx
+++ b/client/src/pages/NotesPage.jsx
@@ -38,17 +38,17 @@ const NotesPage = () => {
   };
 
   return (
-    <div className="flex h-screen bg-background">
+    <div className="flex h-screen bg-background overflow-hidden">
       <Sidebar />
       <main
         className={`
-          flex-1 flex flex-col
+          flex-1 flex flex-col overflow-hidden
           transition-all duration-500 ease-in-out
           ${isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"}
         `}
       >
         <DashboardHeader />
-        <div className="flex-1 relative">
+        <div className="flex-1 relative overflow-hidden">
           <div className="absolute top-2 right-4 z-10">
             <Button
               size="sm"


### PR DESCRIPTION
makes notes panel page's panels: folder navbar, notes list, and note editor individually scrollable. instead of the whole page being scrollable.
closes #3 