### PR TITLE
Fix/note folders stored globally

### DIFF
--- a/client/src/features/Notes/components/layout/NotesPageLayout.jsx
+++ b/client/src/features/Notes/components/layout/NotesPageLayout.jsx
@@ -33,10 +33,10 @@ const NotesPageLayout = () => {
   const location = useLocation();
 
   // React Query hooks
+  const { data: folders = [DEFAULT_FOLDER] } = useFoldersQuery();
   const { data: notes = [], isLoading: notesLoading } = useNotesQuery({
     folder: currentFolder,
   });
-  const { data: folders = [DEFAULT_FOLDER] } = useFoldersQuery();
   const createNoteMutation = useCreateNoteMutation();
   const updateNoteMutation = useUpdateNoteMutation();
   const deleteNoteMutation = useDeleteNoteMutation();

--- a/client/src/features/authentication/store/authStore.js
+++ b/client/src/features/authentication/store/authStore.js
@@ -5,6 +5,7 @@ import {
   initializeSocket,
   disconnectSocket,
 } from "../../../services/socketService";
+import { queryClient } from "../../../config/queryClient";
 
 /**
  * Authentication store using Zustand
@@ -118,6 +119,13 @@ export const useAuthStore = create(
             }
           }
 
+          // Clear React Query cache to prevent data leakage between users
+          try {
+            queryClient.clear();
+          } catch (error) {
+            console.error("Error clearing React Query cache:", error);
+          }
+
           // Clear auth state regardless of API call success
           set({
             user: null,
@@ -164,6 +172,7 @@ export const useAuthStore = create(
                   return true;
                 }
               } catch (refreshError) {
+                console.error("Error refreshing token:", refreshError);
                 // If refresh fails, clear auth state
                 useAuthStore.getState().logout();
                 return false;

--- a/client/src/services/api/apiClient.js
+++ b/client/src/services/api/apiClient.js
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { queryClient } from "../../config/queryClient";
 
 // Create axios instance with custom config
 const apiClient = axios.create({
@@ -133,6 +134,13 @@ apiClient.interceptors.response.use(
                 cleanupError
               );
             }
+          }
+
+          // Clear React Query cache to prevent data leakage between users
+          try {
+            queryClient.clear();
+          } catch (cacheError) {
+            console.error("Error clearing React Query cache:", cacheError);
           }
 
           // Redirect to login (optional - can be handled by the component)


### PR DESCRIPTION
## Problem
Issue #19: Note folders appear for new users on the same browser because of shared localStorage and React Query cache.

## Root Cause
- localStorage and React Query cache keys were global, not user-specific
- **`useFoldersQuery` wasn't running its `queryFn`** because it found `initialData` from localStorage (even `null`), and React Query considers `null` as valid cached data, so it doesn't fetch
- No cache clearing between user sessions

## Solution
- **User-specific query keys**: All React Query keys now include `userId`
- **Fix `initialData` validation**: Return `undefined` instead of `[DEFAULT_FOLDER]` when no valid localStorage data exists, forcing React Query to run the `queryFn`
- **Smart folder derivation**: Extract folders from cached notes data instead of separate API calls
- **Cache isolation**: Clear React Query cache on logout and auth failures

## Result
✅ Each user only sees their own folders  
✅ Folders appear correctly in notes page navbar  
✅ No data leakage between user sessions  
✅ Better performance with cached data reuse  

Resolves #19