### PR TITLE
remove ci matrix strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,18 +54,14 @@ jobs:
     name: Test Frontend
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [18, 20, 22]
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Node.js ${{ matrix.node-version }}
+      - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
 
       - name: Install client dependencies
@@ -78,7 +74,6 @@ jobs:
         run: cd client && npm run build
 
       - name: Upload client build artifacts
-        if: matrix.node-version == 20 # Only upload once
         uses: actions/upload-artifact@v4
         with:
           name: client-build
@@ -90,10 +85,6 @@ jobs:
     name: Test Backend
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [18, 20, 22]
-
     services:
       mongodb:
         image: mongo:7.0
@@ -104,10 +95,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Node.js ${{ matrix.node-version }}
+      - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
 
       - name: Install server dependencies

--- a/docs/ci-cd-pipeline.md
+++ b/docs/ci-cd-pipeline.md
@@ -29,11 +29,11 @@ This document outlines the CI/CD pipeline implementation for the FlowFocus MERN 
 
 #### 2. **Test Frontend** ⚛️
 
-- **Purpose**: Validates React frontend functionality across Node.js versions
+- **Purpose**: Validates React frontend functionality
 - **What it does**:
   - Runs Jest tests for the React app
   - Builds the Vite production bundle
-  - Tests on Node.js 18, 20, and 22
+  - Tests on Node.js 20
   - Uploads build artifacts for review
 - **Tools**: Jest, Vite, Testing Library
 
@@ -42,7 +42,7 @@ This document outlines the CI/CD pipeline implementation for the FlowFocus MERN 
 - **Purpose**: Validates Express backend functionality with real MongoDB
 - **What it does**:
   - Runs Jest tests with MongoDB test instance
-  - Tests on Node.js 18, 20, and 22
+  - Tests on Node.js 20
   - Uses MongoDB Docker service for integration tests
 - **Tools**: Jest, Supertest, MongoDB Memory Server
 
@@ -92,8 +92,8 @@ This document outlines the CI/CD pipeline implementation for the FlowFocus MERN 
 The following checks must pass before merging PRs:
 
 - ✅ Code Quality & Linting
-- ✅ Test Frontend (Node.js 18, 20, 22)
-- ✅ Test Backend (Node.js 18, 20, 22)
+- ✅ Test Frontend (Node.js 20)
+- ✅ Test Backend (Node.js 20)
 - ✅ Security Audit
 - ✅ Integration Check
 - ✅ Conventional Commits (PRs only)
@@ -104,7 +104,7 @@ The following checks must pass before merging PRs:
 
 - **Early Issue Detection**: Catches problems before they reach main branches
 - **Consistent Code Quality**: Automated formatting and linting enforcement
-- **Cross-Environment Testing**: Validates compatibility across Node.js versions
+- **Standardized Environment**: Validates functionality on Node.js 20
 - **Security Awareness**: Regular dependency vulnerability scanning
 
 ### **For CV/Portfolio**


### PR DESCRIPTION
use just node v20 instead of 18, 20 and 22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated CI workflow to run tests on a single Node.js version (20) instead of multiple versions.
  - Simplified artifact upload process in the CI pipeline.
- **Documentation**
  - Updated CI/CD pipeline documentation to reflect testing on only Node.js 20 and clarified environment standardization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->