### PR TITLE
fix(ci): remove SSH host key bypass vulnerability

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,7 @@ jobs:
 
       - name: Add VPS to known hosts
         run: |
+          # Get the current VPS host key and add to known_hosts for secure connection
           ssh-keyscan -H ${{ secrets.VPS_HOST }} >> ~/.ssh/known_hosts
 
       - name: Deploy to VPS
@@ -78,7 +79,7 @@ jobs:
           sudo chmod 600 /root/.ssh/flowfocus_deploy
 
           # Configure git to use the deployment key
-          export GIT_SSH_COMMAND="ssh -i /root/.ssh/flowfocus_deploy -o StrictHostKeyChecking=no"
+          export GIT_SSH_COMMAND="ssh -i /root/.ssh/flowfocus_deploy"
 
           # Ensure GitHub is in known_hosts
           if ! grep -q "github.com" ~/.ssh/known_hosts 2>/dev/null; then
@@ -105,8 +106,8 @@ jobs:
 
           # Pull latest changes using deployment key
           echo "📥 Pulling latest changes with deployment key..."
-          sudo env GIT_SSH_COMMAND="ssh -i /root/.ssh/flowfocus_deploy -o StrictHostKeyChecking=no" git fetch origin
-          sudo env GIT_SSH_COMMAND="ssh -i /root/.ssh/flowfocus_deploy -o StrictHostKeyChecking=no" git reset --hard origin/main
+          sudo env GIT_SSH_COMMAND="ssh -i /root/.ssh/flowfocus_deploy" git fetch origin
+          sudo env GIT_SSH_COMMAND="ssh -i /root/.ssh/flowfocus_deploy" git reset --hard origin/main
           echo "✅ Code updated to latest main branch"
 
           # Install/update dependencies
@@ -162,8 +163,8 @@ jobs:
           chmod +x deploy.sh
 
           # Execute deployment on VPS
-          echo "🔗 Connecting to VPS with deployment key..."
-          ssh -o StrictHostKeyChecking=no ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} 'bash -s' < deploy.sh
+          echo "🔗 Connecting to VPS with verified host key..."
+          ssh ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} 'bash -s' < deploy.sh
 
       - name: Health Check
         run: |
@@ -206,7 +207,7 @@ jobs:
         if: success()
         run: |
           echo "🧹 Cleaning up old backups (keeping last 5)..."
-          ssh -o StrictHostKeyChecking=no ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} '
+          ssh ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} '
             cd /var/www
             # Keep only the 5 most recent backups
             ls -t flowfocus-backup-* 2>/dev/null | tail -n +6 | xargs -r sudo rm -rf


### PR DESCRIPTION
Remove -o StrictHostKeyChecking=no from deployment workflow to prevent Man-in-the-Middle attacks. Use ssh-keyscan to properly verify VPS host keys before connections.

## Context:
after successfully running the production workflow. got this warning trying to ssh back into vps from local machine:
```
~  $ ssh HLB1C
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!     @
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!
Someone could be eavesdropping on you right now (man-in-the-middle attack)!
It is also possible that a host key has just been changed.
The fingerprint for the ED25519 key sent by the remote host is
SHA256:bmNQlPYfE81P1zWypAHMLgtNpYN7iIHTACmxU5JKh/8.
Please contact your system administrator.
Add correct host key in /c/Users/MSI/.ssh/known_hosts to get rid of this message.
Offending ECDSA key in /c/Users/MSI/.ssh/known_hosts:6
Host key for <vps ip address> has changed and you have requested strict checking.
Host key verification failed.
```

This occurred because the VPS's host key changed (e.g., due to a rebuild or migration). The GitHub Actions deployment script, specifically by using ssh-keyscan and -o StrictHostKeyChecking=no, allowed the CI/CD pipeline to connect to the "new" VPS with its updated key without complaint. However, the local SSH client still had the old key stored for the VPS's IP address. When the client detected this mismatch, it correctly flagged a security warning, as its primary job is to protect against potential Man-in-the-Middle attacks.

Fixes #28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved deployment security by enforcing SSH host key verification during deployment.
  - Updated workflow comments for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->